### PR TITLE
Added support for vacation forwarder to SQL config

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -63,8 +63,8 @@ $rcmail_config['vacation_sql_read'] =
 	array("SELECT subject AS vacation_subject, body AS vacation_message, " .
 	          "active AS vacation_enable FROM vacation " .
 	      "WHERE email=%username AND domain=%email_domain;",
-              "SELECT SUBSTRING(goto,INSTR(goto,'autoreply.%email_domain')" .
-                  "+CHAR_LENGTH('autoreply.%email_domain')+1) " .
+              "SELECT SUBSTRING(goto,INSTR(goto,'autoreply.my.domain')" .
+                  "+CHAR_LENGTH('autoreply.my.domain')+1) " .
                   "AS vacation_forwarder FROM alias " .
               "WHERE address=%username AND domain=%email_domain;"
 	     );
@@ -82,7 +82,7 @@ $rcmail_config['vacation_sql_write'] =
           "INSERT INTO alias (address,goto,domain,created,modified," .
 	         "active) " .
              "SELECT %email,CONCAT(%email,',',%email_local,'#',%email_domain,'@'," .
-                "'autoreply.%email_domain,',%vacation_forwarder)," .
+                "'autoreply.my.domain,',%vacation_forwarder)," .
                 "%email_domain,NOW(),NOW(),1 " .
              "FROM mailbox WHERE username=%email AND " .
                 "domain=%email_domain AND %vacation_enable=1;"

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -63,7 +63,9 @@ $rcmail_config['vacation_sql_read'] =
 	array("SELECT subject AS vacation_subject, body AS vacation_message, " .
 	          "active AS vacation_enable FROM vacation " .
 	      "WHERE email=%username AND domain=%email_domain;",
-              "SELECT goto AS vacation_forwarder FROM alias " .
+              "SELECT SUBSTRING(goto,INSTR(goto,'autoreply.%email_domain')" .
+                  "+CHAR_LENGTH('autoreply.%email_domain')+1) " .
+                  "AS vacation_forwarder FROM alias " .
               "WHERE address=%username AND domain=%email_domain;"
 	     );
 

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -72,18 +72,23 @@ $rcmail_config['vacation_sql_write'] =
 	array("DELETE FROM vacation WHERE email=%email AND " .
 	         "domain=%email_domain;",
           "DELETE from vacation_notification WHERE on_vacation=%email;",
-          "UPDATE alias SET goto=%vacation_forwarder " .
-                 "WHERE address=%email AND domain=%email_domain;",
+          "DELETE FROM alias WHERE address=%email AND " .
+                 "domain=%email_domain;",
           "INSERT INTO vacation (email,domain,subject,body,created," .
 	         "active) VALUES (%email,%email_domain,%vacation_subject," .
 	            "%vacation_message,NOW(),%vacation_enable);",
           "INSERT INTO alias (address,goto,domain,created,modified," .
 	         "active) " .
              "SELECT %email,CONCAT(%email,',',%email_local,'#',%email_domain,'@'," .
-                "'autoreply.my.domain,',%vacation_forwarder)," .
+                "'autoreply.%email_domain,',%vacation_forwarder)," .
                 "%email_domain,NOW(),NOW(),1 " .
              "FROM mailbox WHERE username=%email AND " .
                 "domain=%email_domain AND %vacation_enable=1;"
+          "INSERT INTO alias (address,goto,domain,created,modified," .
+                 "active) " .
+             "SELECT %email,%vacation_forwarder,%email_domain,NOW(),NOW(),1 " .
+             "FROM mailbox WHERE username=%email AND " .
+                "domain=%email_domain AND %vacation_enable=0;"
     );
 
 /*

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -62,7 +62,9 @@ $rcmail_config['vacation_sql_dsn'] =
 $rcmail_config['vacation_sql_read'] =
 	array("SELECT subject AS vacation_subject, body AS vacation_message, " .
 	          "active AS vacation_enable FROM vacation " .
-	      "WHERE email=%username AND domain=%email_domain;"
+	      "WHERE email=%username AND domain=%email_domain;",
+              "SELECT goto AS vacation_forwarder FROM alias " .
+              "WHERE address=%username AND domain=%email_domain;"
 	     );
 
 // write data queries
@@ -70,15 +72,16 @@ $rcmail_config['vacation_sql_write'] =
 	array("DELETE FROM vacation WHERE email=%email AND " .
 	         "domain=%email_domain;",
           "DELETE from vacation_notification WHERE on_vacation=%email;",
-          "DELETE FROM alias WHERE address=%email AND " .
-	         "domain=%email_domain;",
-	      "INSERT INTO vacation (email,domain,subject,body,created," .
+          "UPDATE alias SET goto=%vacation_forwarder " .
+                 "WHERE address=%email AND domain=%email_domain;",
+          "INSERT INTO vacation (email,domain,subject,body,created," .
 	         "active) VALUES (%email,%email_domain,%vacation_subject," .
 	            "%vacation_message,NOW(),%vacation_enable);",
           "INSERT INTO alias (address,goto,domain,created,modified," .
 	         "active) " .
              "SELECT %email,CONCAT(%email,',',%email_local,'#',%email_domain,'@'," .
-                "'autoreply.my.domain'),%email_domain,NOW(),NOW(),1 " .
+                "'autoreply.my.domain,',%vacation_forwarder)," .
+                "%email_domain,NOW(),NOW(),1 " .
              "FROM mailbox WHERE username=%email AND " .
                 "domain=%email_domain AND %vacation_enable=1;"
     );


### PR DESCRIPTION
With this patch, the SQL config will work when vacation_gui_vacationforwarder is set to TRUE.  The default forwarding address will be taken from the existing entry in the aliases table (if any).  When the vacation message is disabled, the forwarding address will, by default, be retained.

Apart from reading and writing a forwarding address while the vacation is enabled, this also fixes a bug whereby a forwarding address already set in the aliases table (probably using the native postfixadmin Web interface) would be lost when the vacation was set.
