### PR TITLE
keep custom alias and enable forwarding

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -67,27 +67,26 @@ $rcmail_config['vacation_sql_read'] =
 
 // write data queries
 $rcmail_config['vacation_sql_write'] =
-        array("DELETE FROM vacation WHERE email=%email AND " .
-                 "domain=%email_domain;",
-          "DELETE from vacation_notification WHERE on_vacation=%email;",
-          "DELETE FROM alias WHERE address=%email AND " .
-                 "domain=%email_domain;", 
-              "INSERT INTO vacation (email,domain,subject,body,created," .
-                 "active) VALUES (%email,%email_domain,%vacation_subject," .
-                    "%vacation_message,NOW(),%vacation_enable);",
-          "INSERT INTO alias (address,goto,domain,created,modified," .
-                 "active) " .
-             "SELECT %email,CONCAT(%email,',',%email_local,'#',%email_domain,'@'," .
-                "'autoreply.my.domain'),%email_domain,NOW(),NOW(),1 " .
-             "FROM mailbox WHERE username=%email AND " .
-                "domain=%email_domain AND %vacation_enable=1;",
-          "INSERT INTO alias (address,goto,domain,created,modified," .
-                 "active) " .
-             "SELECT %email,%email,%email_domain,NOW(),NOW(),1 " .
-             "FROM mailbox WHERE username=%email AND " .
-                "domain=%email_domain AND %vacation_enable=0;"
-         );
+		array(
+			"DELETE FROM vacation WHERE email=%email AND domain=%email_domain;",
+			"INSERT INTO vacation (email,domain,subject,body,created,active) VALUES (%email,%email_domain,%vacation_subject,%vacation_message,NOW(),%vacation_enable);",
 
+			"DELETE from vacation_notification WHERE on_vacation=%email;",
+
+			//remove auto, but keep custom aliases
+			"UPDATE alias SET goto = replace(goto, CONCAT(',',%email_local,'#',%email_domain,'@','autoreply.my.domain'),''), modified = NOW() 
+				WHERE address=%email AND domain=%email_domain;",
+			//add auto
+			"UPDATE alias SET goto = CONCAT(goto,',',%email_local,'#',%email_domain,'@','autoreply.my.domain'), modified = NOW() 
+				WHERE address=%email AND domain=%email_domain AND %vacation_enable=1;",
+
+			//remove fwd, but keep the other stuff  -- good would be some variable with the old forwarder!..
+			"UPDATE alias SET goto = replace(goto, CONCAT(',',%vacation_forwarder),''), modified = NOW() 
+				WHERE address=%email AND domain=%email_domain;",
+			//add fwd
+			"UPDATE alias SET goto = CONCAT(goto,',',%vacation_forwarder), modified = NOW() 
+				WHERE address=%email AND domain=%email_domain AND %vacation_forwarder!='' AND %vacation_enable=1;",
+		);
 /*
  * LDAP driver
  */

--- a/vacation.php
+++ b/vacation.php
@@ -115,7 +115,7 @@ class vacation extends rcube_plugin
 		if ($this->rc->config->get('vacation_gui_vacationsubject', FALSE))
 		{
 			$field_id = 'vacationsubject';
-			$input_vacationsubject = new html_inputfield(array('name' => '_vacationsubject', 'id' => $field_id, 'size' => 40));
+			$input_vacationsubject = new html_inputfield(array('name' => '_vacationsubject', 'id' => $field_id, 'size' => 95));
 			$table->add('title', html::label($field_id, Q($this->gettext('vacationsubject'))));
 			$table->add(null, $input_vacationsubject->show($this->obj->get_vacation_subject()));
 		}
@@ -127,11 +127,11 @@ class vacation extends rcube_plugin
 			// FIX: use identity mode for minimal functions
 			rcube_html_editor('identity');
 
-			$text_vacationmessage = new html_textarea(array('name' => '_vacationmessage', 'id' => $field_id, 'spellcheck' => 1, 'rows' => 6, 'cols' => 40, 'class' => 'mce_editor'));
+			$text_vacationmessage = new html_textarea(array('name' => '_vacationmessage', 'id' => $field_id, 'spellcheck' => 1, 'rows' => 12, 'cols' => 70, 'class' => 'mce_editor'));
 		}
 		else
 		{
-			$text_vacationmessage = new html_textarea(array('name' => '_vacationmessage', 'id' => $field_id, 'spellcheck' => 1, 'rows' => 6, 'cols' => 40));
+			$text_vacationmessage = new html_textarea(array('name' => '_vacationmessage', 'id' => $field_id, 'spellcheck' => 1, 'rows' => 12, 'cols' => 70));
 		}
 
 		$table->add('title', html::label($field_id, Q($this->gettext('vacationmessage'))));
@@ -148,12 +148,12 @@ class vacation extends rcube_plugin
 		if ($this->rc->config->get('vacation_gui_vacationforwarder', FALSE))
 		{
 			$field_id = 'vacationforwarder';
-			$input_vacationforwarder = new html_inputfield(array('name' => '_vacationforwarder', 'id' => $field_id, 'size' => 20));
+			$input_vacationforwarder = new html_inputfield(array('name' => '_vacationforwarder', 'id' => $field_id, 'size' => 95));
 			$table->add('title', html::label($field_id, Q($this->gettext('vacationforwarder'))));
 			$table->add(null, $input_vacationforwarder->show($this->obj->get_vacation_forwarder()));
 		}
 
-		$out = html::div(array('class' => "box"), html::div(array('id' => "prefs-title", 'class' => 'boxtitle'), $this->gettext('vacation')) . html::div(array('class' => "boxcontent"), $table->show() . html::p(null, $this->rc->output->button(array('command' => 'plugin.vacation-save', 'type' => 'input', 'class' => 'button mainaction', 'label' => 'save')))));
+		$out = html::div(array('class' => "box"), html::div(array('id' => "prefs-title", 'class' => 'boxtitle'), $this->gettext('vacation')) . html::div(array('class' => "boxcontent scroller"), $table->show() . html::p(null, $this->rc->output->button(array('command' => 'plugin.vacation-save', 'type' => 'input', 'class' => 'button mainaction', 'label' => 'save')))));
 
 		$this->rc->output->add_gui_object('vacationform', 'vacation-form');
 


### PR DESCRIPTION
hey there, i switched the vacation-plugin of my setup today, after upgrading rc, so i had to dive into this again.

according to the sql-driver: i combined @lluis solution for keeping custom aliases with the need of forwarding. so here is an other set of default sql.
this is still not perfect! since the user, in order to remove a forwarding would have to deactivate that without changing the forwarding adresses. so one should either lock editing the forwarder, while the responder is active or keep track of the previous forwarder and provide it in a variable in order to remove it. also a checkbox to enable, disable forwarding separatly would be great. i didnt have the time today to dive deeper into the rc-pluginstuff, so i leave it as is and hope someone else who knows the rc-stuff is going to do that.

i also did little on the layout.

changes:
config.inc.php.dist
- SQL: nondestructive adding and removing of autoresponder and forwarder

vacation.php
- scrollable settingsframe for small windows
- bigger inputfields

todo:
- [ ] keep track of previous forward OR enable/disable forwarding seperatly
