### PR TITLE
Default calendar format js include

### DIFF
--- a/vacation.php
+++ b/vacation.php
@@ -39,7 +39,8 @@ class vacation extends rcube_plugin
 		if ($this->rc->config->get('vacation_gui_vacationdate', FALSE) && $this->rc->config->get('vacation_jquery_calendar', FALSE))
 		{
 			$format = $this->rc->config->get('vacation_jquery_dateformat', 'mm/dd/yy');
-			$rcmail->output->add_script("calendar_format='" . $format . "';");
+			if($rcmail->output->type === "html")
+			    $this->rc->output->add_script("calendar_format='" . $format . "';");
 			$this->include_script('vacation_calendar.js');
 		}
 			


### PR DESCRIPTION
The way the calendar format string was added to the js of the page didn't work anymore with rc-0.9. I've changed the method and now it works again for me.
